### PR TITLE
Remove 'num_randomizers' argument from MemoryTable.derive_matrix()

### DIFF
--- a/code/brainfuck_stark.py
+++ b/code/brainfuck_stark.py
@@ -146,7 +146,7 @@ class BrainfuckStark:
 
         # instantiate other table objects
         self.memory_table.matrix = MemoryTable.derive_matrix(
-            self.processor_table.matrix, self.num_randomizers)
+            self.processor_table.matrix)
 
         # create proof stream if we don't have it already
         if proof_stream == None:

--- a/code/memory_table.py
+++ b/code/memory_table.py
@@ -16,7 +16,7 @@ class MemoryTable(Table):
             field, 3, 4, length, num_randomizers, generator, order)
 
     @staticmethod
-    def derive_matrix(processor_matrix, num_randomizers):
+    def derive_matrix(processor_matrix):
         matrix = [[pt[ProcessorTable.cycle], pt[ProcessorTable.memory_pointer],
                   pt[ProcessorTable.memory_value]] for pt in processor_matrix]
         matrix.sort(key=lambda mt: mt[MemoryTable.memory_pointer].value)


### PR DESCRIPTION
This parameter was not in use.

Merge this if it's correct.

Reject and close if not. In that case, perhaps `derive_matrix()` should probably make use of it.