### PR TITLE
Fix error in symbolic degree bounds evaluation for mpols

### DIFF
--- a/code/multivariate.py
+++ b/code/multivariate.py
@@ -152,7 +152,9 @@ class MPolynomial:
                0])), f"max degrees length ({len(max_degrees)}) does not match with number of variables (key for first term: {list(self.dictionary.keys())[0]})"
         assert(max_degrees == [max_degrees[0]] * len(max_degrees)
                ), "max degrees must be n repetitions of the same integer"
-        for exponents, _ in self.dictionary.items():
+        for exponents, coefficient in self.dictionary.items():
+            if coefficient.is_zero():
+                continue
             term_degree_bound = 0
             for e, md in zip(exponents, max_degrees):
                 term_degree_bound += e * md

--- a/code/test_multivariate.py
+++ b/code/test_multivariate.py
@@ -1,0 +1,44 @@
+from algebra import *
+from multivariate import MPolynomial
+from extension_field import *
+from univariate import *
+from ntt import *
+import os
+
+
+def test_symbolic_bounds_zero_coefficient_zero_input():
+    field = ExtensionField.main()
+    linear = MPolynomial({(0, 1): field.one()})
+    sym_eval = linear.symbolic_degree_bound([-1, -1])
+    assert(sym_eval == -1)
+
+    # Add a zero-coefficient and verify that the result is unchanged
+    linear_alt = MPolynomial({(0, 1): field.one(), (0, 0): field.zero()})
+    sym_eval_alt = linear_alt.symbolic_degree_bound([-1, -1])
+    assert(sym_eval_alt == -1)
+    linear_alt_alt = MPolynomial(
+        {(0, 1): field.one(), (100, 42): field.zero()})
+    sym_eval_alt_alt = linear_alt_alt.symbolic_degree_bound([-1, -1])
+    assert(sym_eval_alt_alt == -1)
+    print("Test succeeded \\0/")
+
+
+def test_symbolic_bounds_zero_coefficient_non_zero_input():
+    field = ExtensionField.main()
+    max_degrees = [3, 3, 3]
+    non_linear = MPolynomial({(0, 2, 1): field.one(), (0, 0, 1): field.one()})
+    sym_eval = non_linear.symbolic_degree_bound(max_degrees)
+    assert(sym_eval == 9)
+
+    # Add a zero-coefficient and verify that the result is unchanged
+    non_linear_alt = MPolynomial(
+        {(0, 2, 1): field.one(), (0, 0, 1): field.one(), (3, 3, 4): field.zero()})
+    sym_eval_alt = non_linear_alt.symbolic_degree_bound(max_degrees)
+    assert(sym_eval_alt == 9)
+
+    # Change to a non-zero coefficient and verify that the result has changed
+    new_mpolynomial = MPolynomial(
+        {(0, 2, 1): field.one(), (0, 0, 1): field.one(), (3, 3, 4): field.one()})
+    sym_eval_new = new_mpolynomial.symbolic_degree_bound(max_degrees)
+    assert(sym_eval_new != 9)
+    print("Test succeeded \\0/")


### PR DESCRIPTION
When the coefficient is zero for a term in a multivariate polynomium
this term must not count towards the degree of the evaluated univariate
polynomium degree.

Two tests have been added, and the entire STARK Brainfuck engine for
proof + verify have been verified to still work with four programs:
`++++`, Hello World, `,.,.,{.x17}`, and a program that prints 17 '!'.

All four programs worked before and after this change, so this error
didn't seem to affect the completeness of the proofs.