### PR TITLE
Fix is_zero soundness error

### DIFF
--- a/code/test_brainfuck_stark.py
+++ b/code/test_brainfuck_stark.py
@@ -42,7 +42,7 @@ def mallorys_simulator(program, input_data=[]):
                               register.next_instruction,
                               register.memory_pointer,
                               register.memory_value,
-                              register.is_zero]]
+                              register.memory_value_inverse]]
 
         instruction_matrix += [[register.instruction_pointer,
                                 register.current_instruction,
@@ -119,13 +119,13 @@ def mallorys_simulator(program, input_data=[]):
         register.memory_value = memory.get(register.memory_pointer, zero)
 
         if register.memory_value.is_zero():
-            register.is_zero = one
+            register.memory_value_inverse = zero
         else:
-            register.is_zero = zero
+            register.memory_value_inverse = register.memory_value.inverse()
 
         # This is the 2nd part of the attack
         if register.current_instruction == F('['):
-            register.is_zero = zero
+            register.memory_value_inverse = BaseFieldElement(42, field)
 
     # collect final state into execution tables
     processor_matrix += [[register.cycle,
@@ -134,7 +134,7 @@ def mallorys_simulator(program, input_data=[]):
                           register.next_instruction,
                           register.memory_pointer,
                           register.memory_value,
-                          register.is_zero]]
+                          register.memory_value_inverse]]
 
     instruction_matrix += [[register.instruction_pointer,
                             register.current_instruction,
@@ -245,5 +245,6 @@ def set_adversarial_is_zero_value_test():
     mallorys_proof = mallorys_bfs.prove(len(mallorys_processor_matrix), program, mallorys_processor_matrix,
                                         mallorys_instruction_matrix, mallorys_input_matrix, mallorys_output_matrix)
     success_of_mallory = mallorys_bfs.verify(mallorys_proof)
-    print("verdict_of_mallory = ", success_of_mallory)
     assert not success_of_mallory, "Mallory's proof must fail to verify"
+    print("Mallory's attack was defeated.")
+    print("https://youtu.be/4aof9KxIJZo")

--- a/code/vm.py
+++ b/code/vm.py
@@ -64,7 +64,7 @@ class Register:
         self.next_instruction = Register.field.zero()
         self.memory_pointer = Register.field.zero()
         self.memory_value = Register.field.zero()
-        self.is_zero = Register.field.one()
+        self.memory_value_inverse = Register.field.zero()
 
 
 class VirtualMachine:
@@ -197,7 +197,7 @@ class VirtualMachine:
                                   register.next_instruction,
                                   register.memory_pointer,
                                   register.memory_value,
-                                  register.is_zero]]
+                                  register.memory_value_inverse]]
 
             instruction_matrix += [[register.instruction_pointer,
                                     register.current_instruction,
@@ -271,9 +271,9 @@ class VirtualMachine:
             register.memory_value = memory.get(register.memory_pointer, zero)
 
             if register.memory_value.is_zero():
-                register.is_zero = one
+                register.memory_value_inverse = zero
             else:
-                register.is_zero = zero
+                register.memory_value_inverse = register.memory_value.inverse()
 
         # collect final state into execution tables
         processor_matrix += [[register.cycle,
@@ -282,7 +282,7 @@ class VirtualMachine:
                               register.next_instruction,
                               register.memory_pointer,
                               register.memory_value,
-                              register.is_zero]]
+                              register.memory_value_inverse]]
 
         instruction_matrix += [[register.instruction_pointer,
                                 register.current_instruction,


### PR DESCRIPTION
The register `is_zero` is replaced by `memory_value_inverse`, which is
defined as:
`memory_value == 0 => memory_value_inverse = 0`,
`memory_value != 0 => memory_value_inverse = memory_value^(-1)`.
The expression `(memory_value * memory_value_inverse - 1)` can be used
like `is_zero`. The (old) constraints involving `is_zero` are replaced
to check consistency of the `memory_value_inverse`, as described above.

This fix includes a test checking for this former soundness error. It can be run from the
`code` directory by typing:
```
rm proof.dump; pypy3
from test_brainfuck_stark import *
set_adversarial_is_zero_value_test()
```

Merging this closes #35.
    
This solution does not add an extra register to the VM simulation. It
was architected by Ferdinand Sauer and Alan Szeipieniec.