### PR TITLE
fix some oversights

### DIFF
--- a/code/test_vm.py
+++ b/code/test_vm.py
@@ -8,7 +8,7 @@ def test_vm():
     expected_output = "Hello World!\n"
     #program = ">++++++++++[>+++><<-]>+++><<>."
     #expected_output = "!"
-    input_data, output_data = VirtualMachine.execute(code)
+    running_time, input_data, output_data = VirtualMachine.execute(code)
     output_data = "".join(od for od in output_data)
     assert(output_data ==
            expected_output), f"output data invalid; given:\"{output_data}\", but should be \"{expected_output}\""

--- a/code/vm.py
+++ b/code/vm.py
@@ -72,7 +72,7 @@ class VirtualMachine:
 
     def execute(brainfuck_code):
         program = VirtualMachine.compile(brainfuck_code)
-        running_time, input_data, output_data = VirtualMachine.perform(program)
+        running_time, input_data, output_data = VirtualMachine.run(program)
         return running_time, input_data, output_data
 
     def compile(brainfuck_code):
@@ -342,4 +342,3 @@ class VirtualMachine:
             b * current_instruction + c * next_instruction
 
         return running_sum
-


### PR DESCRIPTION
- Increase the return parameter `running_time`
   `running_time,input_data, output_data = VirtualMachine.execute(code)`

- Modify the perform method to the `run` method