### PR TITLE
fix memory padding function

### DIFF
--- a/code/memory_table.py
+++ b/code/memory_table.py
@@ -40,8 +40,8 @@ class MemoryTable(Table):
     def pad(self):
         one = self.matrix[0][MemoryTable.cycle].field.one()
         while len(self.matrix) & (len(self.matrix) - 1) != 0:
-            self.matrix += [self.matrix[-1][MemoryTable.cycle] + one, self.matrix[-1]
-                            [MemoryTable.memory_pointer], self.matrix[-1][MemoryTable.memory_value], one]
+            self.matrix.append([self.matrix[-1][MemoryTable.cycle] + one, self.matrix[-1]
+                            [MemoryTable.memory_pointer], self.matrix[-1][MemoryTable.memory_value], one])
 
     @staticmethod
     def transition_constraints_afo_named_variables(cycle, address, value, dummy, cycle_next, address_next, value_next, dummy_next):


### PR DESCRIPTION
The function `pad` in `memory_table.py` is incorrect. In the `while` loop, instead of adding a row of $4$ elements to the matrix, it adds each element separately, causing the size of the matrix to increase by $4$ instead of $1$. Using the `append` function should solve this issue.